### PR TITLE
Removed explicit dependency reference to `psr/http-message`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
     "php-http/httplug": "^2.0",
     "psr/http-client-implementation": "^1.0",
     "psr/http-factory-implementation": "^1.0",
-    "psr/http-message": "^1.0",
     "psr/log": "^1.0|^2.0|^3.0",
     "psr/simple-cache": "^3.0"
   },


### PR DESCRIPTION
Explicit dependency specification is removed because there is already a transitive dependency via the `php-http/client-common` package