### PR TITLE
fix operation code change admin

### DIFF
--- a/src/Olifanton/Ton/Contracts/Jetton/JettonMinter.php
+++ b/src/Olifanton/Ton/Contracts/Jetton/JettonMinter.php
@@ -117,7 +117,7 @@ class JettonMinter extends AbstractContract
     {
         try {
             return (new Builder())
-                ->writeUint(2, 32)
+                ->writeUint(3, 32)
                 ->writeUint($queryId, 64)
                 ->writeAddress($newAdminAddress)
                 ->cell();

--- a/tests/Olifanton/Ton/Tests/Contracts/Jetton/JettonMinterTest.php
+++ b/tests/Olifanton/Ton/Tests/Contracts/Jetton/JettonMinterTest.php
@@ -110,7 +110,7 @@ class JettonMinterTest extends TestCase
         $body = JettonMinter::createChangeAdminBody($newAdminAddress);
         $slice = $body->beginParse();
 
-        $this->assertEquals(BigInteger::of("2"), $slice->loadUint(32));
+        $this->assertEquals(BigInteger::of("3"), $slice->loadUint(32));
         $this->assertEquals(BigInteger::zero(), $slice->loadUint(64));
         $this->assertEquals(
             $newAdminAddress->getHashPart(),


### PR DESCRIPTION
Fix incorrect operation code for admin change (was 2, now 3) to match the contract definition and properly invoke the intended operation.






